### PR TITLE
fix(ListLinkHelpers): pass class options

### DIFF
--- a/app/helpers/list_link_helpers.rb
+++ b/app/helpers/list_link_helpers.rb
@@ -3,11 +3,6 @@ module ListLinkHelpers
 
   # List link helpers
   def list_link_to(action, url, options = {})
-    classes = []
-    if class_options = options.delete(:class)
-      classes << class_options.split(' ')
-    end
-
     icon = options.delete(:icon)
     icon ||= action
 

--- a/spec/helpers/contextual_link_helpers_spec.rb
+++ b/spec/helpers/contextual_link_helpers_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 describe ContextualLinkHelpers do
+  describe "#icon_link_to" do
+    it "adds class options" do
+      expect(helper.icon_link_to(:show, '/dummy', class: 'test')).to have_css('a.test')
+    end
+  end
+
   describe "#action_to_icon" do
     it "returns the action parameter if no action matches" do
       expect(helper.action_to_icon('unknown action')).to eq 'unknown action'

--- a/spec/helpers/list_link_helpers_spec.rb
+++ b/spec/helpers/list_link_helpers_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+describe ListLinkHelpers do
+  describe "#list_link_to" do
+    it "adds class options" do
+      expect(helper.list_link_to(:show, '/dummy', class: 'test')).to have_css('a.test')
+    end
+  end
+end


### PR DESCRIPTION
We did delete the `class` options in our list_link_helpers instead of
passing them to the underlying `link_to` helper.