### PR TITLE
count = 1 default parameter prevents I18n::InvalidPluralizationData e…

### DIFF
--- a/app/helpers/i18n_helpers.rb
+++ b/app/helpers/i18n_helpers.rb
@@ -36,7 +36,7 @@ module I18nHelpers
   #   t_model(Account.new) => 'Konto'
   #   t_model              => 'Konto' # when called in patients_controller views
   #
-  def t_model(model = nil)
+  def t_model(model = nil, count = 1)
     if model.is_a? ActiveModel::Naming
       return model.model_name.human
     elsif model.class.is_a? ActiveModel::Naming
@@ -48,7 +48,7 @@ module I18nHelpers
     else
       model_name = model.class.name.underscore
     end
-    I18n::translate(model_name, :scope => [:activerecord, :models])
+    I18n::translate(model_name, :scope => [:activerecord, :models], count: count)
   end
 
   # Returns translated title for current +action+ on +model+.

--- a/app/helpers/i18n_helpers.rb
+++ b/app/helpers/i18n_helpers.rb
@@ -37,10 +37,9 @@ module I18nHelpers
   #   t_model             => 'Kunde'  # when called in clients_controller views
   #
   # using pluralization:
-  #   t_model(Client, 2)  => 'Kunden'
   #   t_model(count:2)    => 'Kunden' # when called in clients_controller views
   #
-  def t_model(model: nil, count: 1)
+  def t_model(model = nil, count: 1)
     if model.is_a? ActiveModel::Naming
       return model.model_name.human
     elsif model.class.is_a? ActiveModel::Naming

--- a/app/helpers/i18n_helpers.rb
+++ b/app/helpers/i18n_helpers.rb
@@ -32,11 +32,15 @@ module I18nHelpers
   # singularize it. +model+ can be both a class or an actual instance.
   #
   # Example:
-  #   t_model(Account)     => 'Konto'
-  #   t_model(Account.new) => 'Konto'
-  #   t_model              => 'Konto' # when called in patients_controller views
+  #   t_model(Client)     => 'Kunde'
+  #   t_model(Client.new) => 'Kunde'
+  #   t_model             => 'Kunde'  # when called in clients_controller views
   #
-  def t_model(model = nil, count = 1)
+  # using pluralization:
+  #   t_model(Client, 2)  => 'Kunden'
+  #   t_model(count:2)    => 'Kunden' # when called in clients_controller views
+  #
+  def t_model(model: nil, count: 1)
     if model.is_a? ActiveModel::Naming
       return model.model_name.human
     elsif model.class.is_a? ActiveModel::Naming
@@ -48,7 +52,7 @@ module I18nHelpers
     else
       model_name = model.class.name.underscore
     end
-    I18n::translate(model_name, :scope => [:activerecord, :models], count: count)
+    I18n::translate(model_name, scope: [:activerecord, :models], count: count)
   end
 
   # Returns translated title for current +action+ on +model+.


### PR DESCRIPTION
…xception raised

If the locale yaml has a key.one and key.other for pluralization t_model
made an exeption to be thrown.

This way the exeption is not raised and one could even use pluralization
with the method now.