### PR TITLE
Fix deprecation warning on autoloading constants

### DIFF
--- a/lib/i18n_rails_helpers/engine.rb
+++ b/lib/i18n_rails_helpers/engine.rb
@@ -5,10 +5,12 @@ require 'i18n_rails_helpers/controller_helpers'
 module I18nRailsHelpers
   class Engine < Rails::Engine
     initializer 'i18n_rails_helpers.helper' do
-      ActionView::Base.send :include, I18nHelpers
-      ActionView::Base.send :include, ContextualLinkHelpers
-      ActionView::Base.send :include, ListLinkHelpers
-      ActionController::Base.class_eval { include ControllerHelpers }
+      Rails.application.reloader.to_prepare do
+          ActionView::Base.send :include, I18nHelpers
+          ActionView::Base.send :include, ContextualLinkHelpers
+          ActionView::Base.send :include, ListLinkHelpers
+        end
+        ActionController::Base.class_eval { include ControllerHelpers }
 
       ActiveRecord::Base.class_eval do
         include ModelHelpers


### PR DESCRIPTION
This PR fixes an deprecation warning that I got on running specs.

```
DEPRECATION WARNING: Initialization autoloaded the constants I18nHelpers, ContextualLinkHelpers, and ListLinkHelpers.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload I18nHelpers, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
 (called from <top (required)> at /home/crispin/9elements/PicturePeople/picture-people/config/environment.rb:5)
```

I don't know, if there is a better fix, but with the code changes from this PR, the warning is gone.